### PR TITLE
Add 'maskable' purpose to PWA icons for better UX

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,8 @@ export default defineConfig({
           {
             src: '/assets/logo-192.png',
             sizes: '192x192',
-            type: 'image/png'
+            type: 'image/png',
+            purpose: 'maskable'
           },
           {
             src: '/assets/logo-512.png',


### PR DESCRIPTION
Added the 'maskable' purpose to the 192x192 app icon in the Vite configuration. This modification enhances adaptive icon support, resulting in a more seamless display in supported environments.

Release-Note: Improve PWA icon appearance by setting purpose to 'maskable'