### PR TITLE
Add headers for manifest and service worker in firebase.json

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -7,25 +7,22 @@
     "public": "dist",
     "headers": [
       {
+        "source": "/manifest.json",
+        "headers": [
+          { "key": "Content-Type", "value": "application/json" }
+        ]
+      },
+      {
         "source": "/service-worker.js",
         "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache"
-          }
+          { "key": "Cache-Control", "value": "no-cache" },
+          { "key": "Content-Type", "value": "application/javascript" }
         ]
       }
     ],
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
+      { "source": "**", "destination": "/index.html" }
     ]
   }
 }


### PR DESCRIPTION
Refactor firebase.json to include Content-Type for /manifest.json and /service-worker.js. Set Content-Type for /manifest.json to application/json and for /service-worker.js to application/javascript.

Release-Note: Configure Content-Type headers for better resource handling