### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
                 "@mui/x-data-grid": "^7.23.5",
                 "@toolpad/core": "^0.11.0",
                 "@types/react-router-dom": "^5.3.3",
+                "dompurify": "^3.2.3",
                 "firebase": "^11.1.0",
                 "firebase-admin": "^13.0.2",
                 "react": "^18.3.1",
@@ -4385,7 +4386,7 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5399,6 +5400,15 @@
             "dependencies": {
                 "@babel/runtime": "^7.8.7",
                 "csstype": "^3.0.2"
+            }
+        },
+        "node_modules/dompurify": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.3.tgz",
+            "integrity": "sha512-U1U5Hzc2MO0oW3DF+G9qYN0aT7atAou4AgI0XjWz061nyBPbdxkfdhfy5uMgGn6+oLFCfn44ZGbdDqCzVmlOWA==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
             }
         },
         "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "firebase-admin": "^13.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^6.28.1"
+        "react-router-dom": "^6.28.1",
+        "dompurify": "^3.2.3"
     },
     "devDependencies": {
         "@eslint/js": "^9.17.0",

--- a/src/components/MobileUserTable.tsx
+++ b/src/components/MobileUserTable.tsx
@@ -13,6 +13,7 @@ import {
 import { Add, Delete } from '@mui/icons-material';
 import User from '../models/User';
 import ConfirmDeleteModal from './modals/ConfirmDeleteModal';
+import DOMPurify from 'dompurify';
 
 interface MobileUserTableProps {
     users: User[];
@@ -95,13 +96,13 @@ const MobileUserTable: React.FC<MobileUserTableProps> = ({
                                 secondary={
                                     <>
                                         <a
-                                            href={`mailto:${user.email}`}
+                                            href={`mailto:${DOMPurify.sanitize(user.email)}`}
                                             style={{
                                                 textDecoration: 'none',
                                                 color: 'inherit',
                                             }}
                                         >
-                                            {user.email}
+                                            {DOMPurify.sanitize(user.email)}
                                         </a>
                                         <span
                                             style={{

--- a/src/components/pages/LoginPageDesktop.tsx
+++ b/src/components/pages/LoginPageDesktop.tsx
@@ -37,7 +37,7 @@ const LoginPageDesktop: React.FC<LoginPageDesktopProps> = ({
     const [isForgotPasswordModalOpen, setForgotPasswordModalOpen] =
         useState(false);
 
-    const handleClickShowPassword = () => setShowPassword((show) => !show);
+    const handleClickShowPassword = () => setShowPassword(!showPassword);
 
     function RememberMe() {
         return (

--- a/src/components/pages/LoginPageMobile.tsx
+++ b/src/components/pages/LoginPageMobile.tsx
@@ -15,6 +15,7 @@ import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { Link } from 'react-router-dom';
 import ForgotPasswordModal from '../modals/ForgotPasswordModal';
+import logo from '../../assets/logo.svg';
 
 interface LoginPageMobileProps {
     login: (email: string, password: string) => Promise<{ user?: any; error?: string }>;
@@ -81,80 +82,87 @@ const LoginPageMobile: React.FC<LoginPageMobileProps> = ({ login }) => {
 
     return (
         <>
-            <Box
-                sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    height: '100vh',
-                    padding: 2,
-                }}
-            >
-                <Typography variant="h5" gutterBottom fontWeight="bold" align="center">
-                    Sign In to the Spa Dashboard
-                </Typography>
-                <Typography variant="body2" gutterBottom color="textSecondary" align="center">
-                    Welcome, please sign in to continue
-                </Typography>
-                <form onSubmit={handleSubmit} style={{ width: '100%' }}>
-                    {error && (
-                        <Typography color="error" gutterBottom>
-                            {error}
-                        </Typography>
-                    )}
-                    <TextField
-                        label="Email"
-                        required
-                        fullWidth
-                        margin="normal"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                    />
-                    <TextField
-                        label="Password"
-                        required
-                        fullWidth
-                        margin="normal"
-                        type={showPassword ? 'text' : 'password'}
-                        value={password}
-                        onChange={(e) => setPassword(e.target.value)}
-                        InputProps={{
-                            endAdornment: (
-                                <InputAdornment position="end">
-                                    <Tooltip
-                                        title={showPassword ? 'Hide password' : 'Show password'}
-                                    >
-                                        <IconButton
-                                            aria-label="toggle password visibility"
-                                            onClick={handleClickShowPassword}
-                                            edge="end"
-                                        >
-                                            {showPassword ? <VisibilityOff /> : <Visibility />}
-                                        </IconButton>
-                                    </Tooltip>
-                                </InputAdornment>
-                            ),
-                        }}
-                    />
-                    <RememberMe />
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                            mt: 2,
-                        }}
-                    >
-                        <Link onClick={() => setForgotPasswordModalOpen(true)} to={''}>
-                            <Typography variant="body2">Forgot Password?</Typography>
-                        </Link>
-                        <Button type="submit" variant="contained" color="primary" disabled={loading}>
-                            {loading ? <CircularProgress size={24} /> : 'Sign In'}
-                        </Button>
-                    </Box>
-                </form>
-            </Box>
+			<Box
+				sx={{
+					display: 'flex',
+					flexDirection: 'column',
+					justifyContent: 'center',
+					alignItems: 'center',
+					height: '100vh',
+					margin: 2,
+				}}
+			>
+				<img
+					src={logo}
+					alt="App Logo"
+					width={32}
+					height={32}
+					style={{ margin: 8, borderRadius: '50%' }}
+				/>
+				<Typography variant="h5" gutterBottom fontWeight="bold" align="center">
+					Sign In to the Spa Dashboard
+				</Typography>
+				<Typography variant="body2" gutterBottom color="textSecondary" align="center">
+					Welcome, please sign in to continue
+				</Typography>
+				<form onSubmit={handleSubmit} style={{ width: '100%' }}>
+					{error && (
+						<Typography color="error" gutterBottom>
+							{error}
+						</Typography>
+					)}
+					<TextField
+						label="Email"
+						required
+						fullWidth
+						margin="normal"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+					/>
+					<TextField
+						label="Password"
+						required
+						fullWidth
+						margin="normal"
+						type={showPassword ? 'text' : 'password'}
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+						InputProps={{
+							endAdornment: (
+								<InputAdornment position="end">
+									<Tooltip
+										title={showPassword ? 'Hide password' : 'Show password'}
+									>
+										<IconButton
+											aria-label="toggle password visibility"
+											onClick={handleClickShowPassword}
+											edge="end"
+										>
+											{showPassword ? <VisibilityOff /> : <Visibility />}
+										</IconButton>
+									</Tooltip>
+								</InputAdornment>
+							),
+						}}
+					/>
+					<RememberMe />
+					<Box
+						sx={{
+							display: 'flex',
+							justifyContent: 'space-between',
+							alignItems: 'center',
+							mt: 2,
+						}}
+					>
+						<Link onClick={() => setForgotPasswordModalOpen(true)} to={''}>
+							<Typography variant="body2">Forgot Password?</Typography>
+						</Link>
+						<Button type="submit" variant="contained" color="primary" disabled={loading}>
+							{loading ? <CircularProgress size={24} /> : 'Sign In'}
+						</Button>
+					</Box>
+				</form>
+			</Box>
             <ForgotPasswordModal
                 open={isForgotPasswordModalOpen}
                 onClose={() => setForgotPasswordModalOpen(false)}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,7 +25,7 @@ const AppWithAuth = () => {
 
     // If no user is provided, always render the login page
     if (!user) {
-        return <LoginPage login={login} />;
+        return <LoginPage />;
     }
 
     return (
@@ -148,7 +148,7 @@ const router = createBrowserRouter([
                 path: '/login',
                 Component: () => {
                     const { login } = useAuth();
-                    return <LoginPage login={login} />;
+                    return <LoginPage />;
                 }, // Ensure the login page is accessible directly via /login
             },
         ],

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ const ClientDetailsPage = React.lazy(() => import('./pages/clientDetails'));
 export const LogoutContext = React.createContext<() => void>(() => {});
 
 const AppWithAuth = () => {
-    const { user, login, logout } = useAuth();
+    const { user, logout } = useAuth();
 
     // If no user is provided, always render the login page
     if (!user) {
@@ -147,7 +147,6 @@ const router = createBrowserRouter([
             {
                 path: '/login',
                 Component: () => {
-                    const { login } = useAuth();
                     return <LoginPage />;
                 }, // Ensure the login page is accessible directly via /login
             },

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -44,18 +44,7 @@ const LoginPage = () => {
     if (isMobile) {
         return (
             <LoginPageMobile
-                email={email}
-                setEmail={setEmail}
-                password={password}
-                setPassword={setPassword}
-                rememberMe={rememberMe}
-                setRememberMe={setRememberMe}
-                showPassword={showPassword}
-                setShowPassword={setShowPassword}
-                loading={loading}
-                error={error}
-                setError={setError}
-                handleSubmit={handleSubmit}
+                login={login}
             />
         );
     }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -11,47 +11,17 @@ const LoginPage = () => {
         localStorage.getItem('rememberedEmail') !== null
     );
     const [showPassword, setShowPassword] = useState(false);
-    const [email, setEmail] = useState(
-        localStorage.getItem('rememberedEmail') || ''
-    );
-    const [password, setPassword] = useState('');
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState<string | null>(null);
 
     const theme = useTheme();
     const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-    const handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setLoading(true);
-        setError(null);
-        try {
-            const result = await login(email, password);
-            if (result.error) {
-                setError(result.error);
-            } else if (rememberMe) {
-                localStorage.setItem('rememberedEmail', email);
-            } else {
-                localStorage.removeItem('rememberedEmail');
-            }
-        } catch (error) {
-            setError('An unknown error occurred');
-        } finally {
-            setLoading(false);
-        }
-    };
-
     if (isMobile) {
-        return (
-            <LoginPageMobile
-                login={login}
-            />
-        );
+        return <LoginPageMobile login={login} />;
     }
 
     return (
         <LoginPageDesktop
-            signIn={async (provider, formData) => {
+            signIn={async (_provider, formData) => {
                 const email = formData.get('email') as string;
                 const password = formData.get('password') as string;
                 return login(email, password);


### PR DESCRIPTION
Fixes [https://github.com/IanSkelskey/spa/security/code-scanning/4](https://github.com/IanSkelskey/spa/security/code-scanning/4)

To fix the problem, we need to ensure that the `email` value is properly sanitized before being used in the `href` attribute. We can use a library like `DOMPurify` to sanitize the email value. This will prevent any malicious content from being executed as HTML or JavaScript.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the `MobileUserTable.tsx` file.
3. Use `DOMPurify` to sanitize the `email` value before using it in the `href` attribute.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
